### PR TITLE
Support querystring

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 )
 
 type Client struct {
@@ -16,6 +18,15 @@ type ClientParams func(*Client)
 
 type Params struct {
 	contentId string
+	draftKey  string
+	limit     int
+	offset    int
+	orders    []string
+	q         string
+	fields    []string
+	ids       []string
+	filters   string
+	depth     int
 }
 
 type RequestParams func(*Params)
@@ -32,8 +43,8 @@ func CreateClient(serviceDomain, apiKey string, params ...ClientParams) *Client 
 	return c
 }
 
-func (c *Client) makeRequest(method, endpoint, contentId string) (*http.Request, error) {
-	url := createUrl(c.serviceDomain, endpoint, contentId)
+func (c *Client) makeRequest(method, endpoint string, p *Params) (*http.Request, error) {
+	url := createUrl(c.serviceDomain, endpoint, p)
 
 	req, err := http.NewRequest(GET, url, nil)
 	if err != nil {
@@ -50,15 +61,13 @@ func (c *Client) makeRequest(method, endpoint, contentId string) (*http.Request,
 }
 
 func (c *Client) Get(endpoint string, params ...RequestParams) (interface{}, error) {
-	p := &Params{
-		contentId: "",
-	}
+	p := &Params{}
 
 	for _, params := range params {
 		params(p)
 	}
 
-	req, err := c.makeRequest(GET, endpoint, p.contentId)
+	req, err := c.makeRequest(GET, endpoint, p)
 	res, _ := http.DefaultClient.Do(req)
 
 	if err != nil {
@@ -81,11 +90,44 @@ func parseBody(res *http.Response, v interface{}) error {
 	return decoder.Decode(v)
 }
 
-func createUrl(serviceDomain, endpoint, contentId string) string {
+func createUrl(serviceDomain, endpoint string, p *Params) string {
 	base := fmt.Sprintf("https://%s.%s/api/%s/%s", serviceDomain, BASE_DOMAIN, API_VERSION, endpoint)
-	if contentId != "" {
-		base := fmt.Sprintf("%s/%s", base, contentId)
-		return base
+
+	if p.contentId != "" {
+		base = fmt.Sprintf("%s/%s", base, p.contentId)
+	}
+
+	urlValues := url.Values{}
+	if len(p.draftKey) > 0 {
+		urlValues.Set("draftKey", p.draftKey)
+	}
+	if p.limit != 0 {
+		urlValues.Set("limit", fmt.Sprint(p.limit))
+	}
+	if p.offset != 0 {
+		urlValues.Set("offset", fmt.Sprint(p.offset))
+	}
+	if len(p.orders) > 0 {
+		urlValues.Set("orders", strings.Join(p.orders, ","))
+	}
+	if len(p.q) > 0 {
+		urlValues.Set("q", p.q)
+	}
+	if len(p.fields) > 0 {
+		urlValues.Set("fields", strings.Join(p.fields, ","))
+	}
+	if len(p.ids) > 0 {
+		urlValues.Set("ids", strings.Join(p.ids, ","))
+	}
+	if len(p.filters) > 0 {
+		urlValues.Set("filters", p.filters)
+	}
+	if p.depth != 0 {
+		urlValues.Set("depth", fmt.Sprint(p.depth))
+	}
+
+	if len(urlValues) > 0 {
+		base = fmt.Sprintf("%s?%s", base, urlValues.Encode())
 	}
 
 	return base
@@ -100,5 +142,59 @@ func GlobalDraftKey(v string) ClientParams {
 func ContentId(v string) RequestParams {
 	return func(p *Params) {
 		p.contentId = v
+	}
+}
+
+func DraftKey(v string) RequestParams {
+	return func(p *Params) {
+		p.draftKey = v
+	}
+}
+
+func Limit(v int) RequestParams {
+	return func(p *Params) {
+		p.limit = v
+	}
+}
+
+func Offset(v int) RequestParams {
+	return func(p *Params) {
+		p.offset = v
+	}
+}
+
+func Orders(v []string) RequestParams {
+	return func(p *Params) {
+		p.orders = v
+	}
+}
+
+func Q(v string) RequestParams {
+	return func(p *Params) {
+		p.q = v
+	}
+}
+
+func Fields(v []string) RequestParams {
+	return func(p *Params) {
+		p.fields = v
+	}
+}
+
+func IDs(ids []string) RequestParams {
+	return func(p *Params) {
+		p.ids = ids
+	}
+}
+
+func Filters(v string) RequestParams {
+	return func(p *Params) {
+		p.filters = v
+	}
+}
+
+func Depth(v int) RequestParams {
+	return func(p *Params) {
+		p.depth = v
 	}
 }


### PR DESCRIPTION
Support querystring!

# Usage

```go
c := microcms.CreateClient(serviceDomain, apiKey)
data, _ := c.Get(
	"news",
	microcms.Limit(10),
	microcms.Offset(3),
	microcms.Orders([]string{"title", "-createdAt"}),
	microcms.Fields([]string{"id", "title"}),
	microcms.Q("golang"),
	microcms.IDs([]string{"foo", "bar"}),
	microcms.Filters("createdAt[less_than]2021-10-23"),
	microcms.Depth(1),
)
```