### PR TITLE
Use struct instead of map

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ $ go get github.com/microcmsio/microcms-go-sdk
 
 ### How to use
 
-First, create client.
-
 ```go
 package main
 
@@ -24,21 +22,34 @@ import (
 	"github.com/microcmsio/microcms-go-sdk"
 )
 
+type Content struct {
+	ID          string
+	Title       string
+	Body        string
+	CreatedAt   time.Date
+	UpdatedAt   time.Date
+	PublishedAt *time.Date
+	RevisedAt   *time.Date
+}
+
 func main() {
 	serviceDomain := "YOUR_DOMAIN" // YOUR_DOMAIN is the XXXX part of XXXX.microcms.io
 	apiKey := "YOUR_API_KEY"
 	globalDraftKey := "YOUR_GLOBAL_DRAFT_KEY" // If need 
 
+	// First, create client.
+
 	// If you specify globalDraftKey, please use microcms.GlobalDraftKey
 	c := microcms.CreateClient(serviceDomain, apiKey, microcms.GlobalDraftKey(globalDraftKey))
-}
-```
 
-After, How to use it below.
+	// After, How to use it below.
 
-```go
 	endpoint := "endpoint"
-	contenttId := "contenttId" 
+	contenttId := "contenttId"
+	data := new(Content)
 
-	data, _ := c.Get(endpoint, microcms.ContentId(contentId))
+	_ = c.Get(endpoint, data, microcms.ContentId(contentId))
+
+	fmt.Printf("%+v\n", response)
+}
 ```

--- a/client.go
+++ b/client.go
@@ -60,7 +60,7 @@ func (c *Client) makeRequest(method, endpoint string, p *Params) (*http.Request,
 	return req, nil
 }
 
-func (c *Client) Get(endpoint string, params ...RequestParams) (interface{}, error) {
+func (c *Client) Get(endpoint string, data interface{}, params ...RequestParams) error {
 	p := &Params{}
 
 	for _, params := range params {
@@ -71,17 +71,16 @@ func (c *Client) Get(endpoint string, params ...RequestParams) (interface{}, err
 	res, _ := http.DefaultClient.Do(req)
 
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	defer res.Body.Close()
 
-	var data interface{}
 	if err := parseBody(res, &data); err != nil {
-		return nil, err
+		return err
 	}
 
-	return data, err
+	return err
 }
 
 func parseBody(res *http.Response, v interface{}) error {

--- a/example/main.go
+++ b/example/main.go
@@ -2,15 +2,42 @@ package main
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/microcmsio/microcms-go-sdk"
 )
+
+type ContentBase struct {
+	ID          string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	RevisedAt   *time.Time
+	PublishedAt *time.Time
+}
+type ContentListBase struct {
+	TotalCount int
+	Offset     int
+	Limit      int
+}
+
+type Blog struct {
+	ContentBase
+	Title string
+	Body  string
+}
+
+type BlogList struct {
+	ContentListBase
+	Contents []Blog
+}
 
 func main() {
 	serviceDomain := "YOUR_DOMAIN"
 	apiKey := "YOUR_API_KEY"
 
 	c := microcms.CreateClient(serviceDomain, apiKey)
-	data, _ := c.Get("endpoint")
+	data := new(BlogList)
+	_ = c.Get("endpoint", data)
 
-	fmt.Println(data)
+	fmt.Printf("%+v\n", data)
 }


### PR DESCRIPTION
When `microcms.Get` returns an `interface{}`, the client code must do a type assertion.
This is inconvenient when the nest is deep.

In this pull request, `microcms.Get` takes a pointer to a struct as an argument, like `json.Unmarshal`. 