### PR TITLE
Add detailed error information to method responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,3 +203,16 @@ err := client.Delete(microcms.DeleteParams{
 	ContentID: "my-content-id",
 })
 ```
+
+### Error Handling
+
+```go
+data, err := client.Get(ctx, "endpoint", nil)
+if err != nil {
+    if httpErr, ok := err.(*sdk.HttpResponseError); ok {
+        fmt.Printf("HTTP Status Code: %d\n", httpErr.Response.StatusCode)
+        fmt.Printf("Error Message: %s\n", httpErr.ErrorMessage)
+    }
+    return
+}
+```

--- a/client.go
+++ b/client.go
@@ -72,7 +72,10 @@ func sendRequest(c *Client, req *http.Request, data interface{}) error {
 		if err != nil {
 			return fmt.Errorf("microCMS connection error: %w", err)
 		}
-		return fmt.Errorf("microCMS response error: %s", errorMessage)
+		return &HttpResponseError{
+			Response:     res,
+			ErrorMessage: string(errorMessage),
+		}
 	}
 
 	if strings.Contains(res.Header.Get("Content-Type"), "application/json") {
@@ -82,4 +85,13 @@ func sendRequest(c *Client, req *http.Request, data interface{}) error {
 	}
 
 	return nil
+}
+
+type HttpResponseError struct {
+	Response     *http.Response
+	ErrorMessage string
+}
+
+func (r *HttpResponseError) Error() string {
+	return fmt.Sprintf("response error: StatusCode=%d %s", r.Response.StatusCode, r.ErrorMessage)
 }


### PR DESCRIPTION
This commit modifies the error handling in the client to include detailed HTTP response information when an error occurs. This is achieved by introducing a new HttpResponseError type, which includes the original HTTP response and the error message from the body of the response.